### PR TITLE
New options for openSchulportfolio

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -1,22 +1,19 @@
 <?php
 # Default configuration for iCalEvent Dokuwiki Plugin
 
-# Date format that is used to display the from and to values
-# If you leave this empty '', then the default dformat from /conf/dokuwiki.php will be used.
+# Format string to format the date without the time of an event
 $conf['dayformat'] = "%d.%m.%y";
+# Format string to format the time part of an event
 $conf['timeformat'] = "%H:%M";
-
-# locale definition fpr setlocale
-$conf['locale'] = 'en_EN';
-
+# locale definition for setlocale
+$conf['locale'] = '';
 # should the end dates for each event be shown?
 $conf['showEndDates'] = 0;
-
 # do you wnat the description parsed as an acronym?
 $conf['list_desc_as_acronym']   = false;
-
 # do you want one table per month instead of a huge eventsstable?
 $conf['list_split_months']      = false;
-$conf['hour_offset']      = 0;
-$conf['event_to_next_day'] = false;
-
+# give manual offset to add/remove from the events hour
+$conf['hour_offset'] = 0;
+# fix for google calendar spanning a one day event to the next day
+$meta['event_to_next_day'] = false;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,22 +1,19 @@
 <?php
 # Default configuration for iCalEvent Dokuwiki Plugin
 
-# Date format that is used to display the from and to values
-# If you leave this empty '', then the default dformat from /conf/dokuwiki.php will be used.
-
+# Format string to format the date without the time of an event
 $meta['dayformat'] = array('string');
+# Format string to format the time part of an event
 $meta['timeformat'] = array('string');
-
 # locale setting for setlocale
 $meta['locale'] = array('string');
-
 # should the end dates for each event be shown?
-$meta['showEndDates'] = array(onoff);
-
+$meta['showEndDates'] = array('onoff');
 # do you wnat the description parsed as an acronym?
-$meta['list_desc_as_acronym']   = array(onoff);
-
+$meta['list_desc_as_acronym'] = array('onoff');
 # do you want one table per month instead of a huge eventsstable?
-$meta['list_split_months']      = array(onoff);
-$meta['hour_offset']      = array('string');
-$meta['event_to_next_day']      = array(onoff);
+$meta['list_split_months'] = array('onoff');
+# give manual offset to add/remove from the events hour
+$meta['hour_offset'] = array('string');
+# fix for google calendar spanning a one day event to the next day
+$meta['event_to_next_day'] = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -3,20 +3,20 @@
 
 # Date format that is used to display the from and to values
 # If you leave this empty '', then the default dformat from /conf/dokuwiki.php will be used.
-$conf['dayformat'] = "%d.%m.%y";
-$conf['timeformat'] = "%H:%M";
 
-# locale definition fpr setlocale
-$conf['locale'] = 'en_EN';
+$meta['dayformat'] = array('string');
+$meta['timeformat'] = array('string');
+
+# locale setting for setlocale
+$meta['locale'] = array('string');
 
 # should the end dates for each event be shown?
-$conf['showEndDates'] = 0;
+$meta['showEndDates'] = array(onoff);
 
 # do you wnat the description parsed as an acronym?
-$conf['list_desc_as_acronym']   = false;
+$meta['list_desc_as_acronym']   = array(onoff);
 
 # do you want one table per month instead of a huge eventsstable?
-$conf['list_split_months']      = false;
-$conf['hour_offset']      = 0;
-$conf['event_to_next_day'] = false;
-
+$meta['list_split_months']      = array(onoff);
+$meta['hour_offset']      = array('string');
+$meta['event_to_next_day']      = array(onoff);

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,22 @@
+<?php
+# Default configuration for iCalEvent Dokuwiki Plugin
+
+# Date format that is used to display the from and to values
+# If you leave this empty '', then the default dformat from /conf/dokuwiki.php will be used.
+
+$lang['dayformat'] = "Format string used for formatting the event days";
+$lang['timeformat'] = "Format strung used for formatting the event times";
+
+# locale setting for setlocale
+$lang['locale'] = "Locale string for months names in the correct laguage";
+
+# should the end dates for each event be shown?
+$lang['showEndDates'] = "Should the end dates and times be shown?";
+
+# do you wnat the description parsed as an acronym?
+$lang['list_desc_as_acronym']   = "Should the event description be shown as acronym of the events summary? (Reduces width of table)";
+
+# do you want one table per month instead of a huge eventsstable?
+$lang['list_split_months']      = "Split the event list in months";
+$lang['hour_offset']      = "Adds/subtracts the given ammount ob hours from events times (fix issues with timezones and/or DST)";
+$lang['event_to_next_day']      = "One-day events on goggle calendar are longing into the next day. This option fixes this behaviour";

--- a/style.css
+++ b/style.css
@@ -1,0 +1,10 @@
+table.icalevents {
+    width: 95%;
+}
+table.icalevents th.date {
+    width: 21em;
+}
+
+table.icalevents td span {
+    font-size: 80%;
+}

--- a/syntax.php
+++ b/syntax.php
@@ -109,7 +109,10 @@ class syntax_plugin_icalevents extends DokuWiki_Syntax_Plugin
           #loop over entries and create a table row for each one.
           $rowCount = 0;
           $monthname = "";
-          setlocale(LC_TIME, trim($this->getConf('locale')));
+
+          if ($this->getConf('locale') != "") {
+            setlocale(LC_TIME, trim($this->getConf('locale')));
+          }
 
           $weekStart = strtotime("last monday 00:00");
           $weekEnd = strtotime("next monday 12:00");


### PR DESCRIPTION
- Removed automatic determination fort dformat
- Split date/time formatting to two config options. So we can manipulate the times better.
- Added option to split the events list by month. Added option for monthname locales
- Added automatic DST recognition
- Added option to manually add an hour offset to fix buggy server times/timezones
- Fixed google calender policy of letting end an one day event on the other day (Optional)
- Cleaned up the output, when start and end date are the same )(only start an end times are displayed, not the whole date anymore)

If you like, you can rewiew the changes an pull it into your main repo, so in dont have to fork this thing permanently. I need the options for openSchulportfolio, a dokuwiki based portfolio for schools.
